### PR TITLE
fix: better support for custom HTTP transports

### DIFF
--- a/example/example_test.go
+++ b/example/example_test.go
@@ -67,8 +67,9 @@ func TestCloseableTransport(t *testing.T) {
 	assert.Panics(t, func() {
 		closeable2 := isp.NewCloseableTransport(custom2)
 
-		// Screw things up after creation.
-		custom2.Base = nil
+		// Screw things up after creation by setting a custom transport without
+		// support for CloseIdleConnections as the oauth2.Transport's base.
+		custom2.Base = custom1
 		closeable2.CloseIdleConnections()
 	})
 

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/istreamlabs/go-sdk/isp"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
 )
 
 // TestSerializeEmptyMap tests that an empty map is serialized as an empty
@@ -31,4 +33,46 @@ func TestSerializeEmptyMap(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Contains(t, string(b), `"first_program_start":{}`)
+}
+
+type CustomTransport struct {
+	Base http.RoundTripper
+}
+
+func (t *CustomTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+type CustomTransportWithClose struct {
+	Base http.RoundTripper
+}
+
+func (t *CustomTransportWithClose) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (t *CustomTransportWithClose) CloseIdleConnections() {
+	// Do nothing
+}
+
+func TestCloseableTransport(t *testing.T) {
+	custom1 := &CustomTransport{http.DefaultTransport}
+	assert.Panics(t, func() {
+		// Creation should fail because the custom transport does not implement
+		// the CloseIdleConnections method.
+		isp.NewCloseableTransport(custom1)
+	})
+
+	custom2 := &oauth2.Transport{Base: http.DefaultTransport}
+	assert.Panics(t, func() {
+		closeable2 := isp.NewCloseableTransport(custom2)
+
+		// Screw things up after creation.
+		custom2.Base = nil
+		closeable2.CloseIdleConnections()
+	})
+
+	custom3 := &CustomTransportWithClose{http.DefaultTransport}
+	closeable3 := isp.NewCloseableTransport(custom3)
+	closeable3.CloseIdleConnections()
 }

--- a/isp/api_audit_operations.go
+++ b/isp/api_audit_operations.go
@@ -49,15 +49,8 @@ type ApiGetChannelTimelineRequest struct {
 	ctx context.Context
 	ApiService AuditOperationsApi
 	channelId string
-	offset *int32
 	cursor *string
 	pageSize *int32
-}
-
-// Number of items to skip when calling a paginated API
-func (r ApiGetChannelTimelineRequest) Offset(offset int32) ApiGetChannelTimelineRequest {
-	r.offset = &offset
-	return r
 }
 
 // Current page cursor
@@ -123,9 +116,6 @@ func (a *AuditOperationsApiService) GetChannelTimelineExecute(r ApiGetChannelTim
 		return localVarReturnValue, nil, reportError("channelId must have less than 60 elements")
 	}
 
-	if r.offset != nil {
-		localVarQueryParams.Add("offset", parameterToString(*r.offset, ""))
-	}
 	if r.cursor != nil {
 		localVarQueryParams.Add("cursor", parameterToString(*r.cursor, ""))
 	}

--- a/isp/api_audit_operations_for_organization.go
+++ b/isp/api_audit_operations_for_organization.go
@@ -46,15 +46,8 @@ type ApiGetOrgChannelTimelineRequest struct {
 	ApiService AuditOperationsForOrganizationApi
 	org string
 	channelId string
-	offset *int32
 	cursor *string
 	pageSize *int32
-}
-
-// Number of items to skip when calling a paginated API
-func (r ApiGetOrgChannelTimelineRequest) Offset(offset int32) ApiGetOrgChannelTimelineRequest {
-	r.offset = &offset
-	return r
 }
 
 // Current page cursor
@@ -118,9 +111,6 @@ func (a *AuditOperationsForOrganizationApiService) GetOrgChannelTimelineExecute(
 		return localVarReturnValue, nil, reportError("channelId must have less than 60 elements")
 	}
 
-	if r.offset != nil {
-		localVarQueryParams.Add("offset", parameterToString(*r.offset, ""))
-	}
 	if r.cursor != nil {
 		localVarQueryParams.Add("cursor", parameterToString(*r.cursor, ""))
 	}

--- a/isp/client.go
+++ b/isp/client.go
@@ -96,6 +96,10 @@ func (t *CloseableTransport) CloseIdleConnections() {
 		base = o.Base
 	}
 
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
 	if closer, ok := base.(idleConnectionsCloser); ok {
 		closer.CloseIdleConnections()
 	} else {

--- a/isp/model_channel_transcode_video_encoders_inner_h265_hdr.go
+++ b/isp/model_channel_transcode_video_encoders_inner_h265_hdr.go
@@ -20,8 +20,6 @@ var _ MappedNullable = &ChannelTranscodeVideoEncodersInnerH265Hdr{}
 type ChannelTranscodeVideoEncodersInnerH265Hdr struct {
 	DolbyVision *ChannelTranscodeVideoEncodersInnerH265HdrDolbyVision `json:"dolby_vision,omitempty"`
 	Hdr10 *ChannelTranscodeVideoEncodersInnerH265HdrHdr10 `json:"hdr10,omitempty"`
-	// Only one of ['hlg', 'hdr10', 'dolby_vision'] may be set.
-	Hlg *map[string]interface{} `json:"hlg,omitempty"`
 }
 
 // NewChannelTranscodeVideoEncodersInnerH265Hdr instantiates a new ChannelTranscodeVideoEncodersInnerH265Hdr object
@@ -105,38 +103,6 @@ func (o *ChannelTranscodeVideoEncodersInnerH265Hdr) SetHdr10(v ChannelTranscodeV
 	o.Hdr10 = &v
 }
 
-// GetHlg returns the Hlg field value if set, zero value otherwise.
-func (o *ChannelTranscodeVideoEncodersInnerH265Hdr) GetHlg() map[string]interface{} {
-	if o == nil || IsNil(o.Hlg) {
-		var ret map[string]interface{}
-		return ret
-	}
-	return *o.Hlg
-}
-
-// GetHlgOk returns a tuple with the Hlg field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ChannelTranscodeVideoEncodersInnerH265Hdr) GetHlgOk() (*map[string]interface{}, bool) {
-	if o == nil || IsNil(o.Hlg) {
-		return nil, false
-	}
-	return o.Hlg, true
-}
-
-// HasHlg returns a boolean if a field has been set.
-func (o *ChannelTranscodeVideoEncodersInnerH265Hdr) HasHlg() bool {
-	if o != nil && !IsNil(o.Hlg) {
-		return true
-	}
-
-	return false
-}
-
-// SetHlg gets a reference to the given map[string]interface{} and assigns it to the Hlg field.
-func (o *ChannelTranscodeVideoEncodersInnerH265Hdr) SetHlg(v map[string]interface{}) {
-	o.Hlg = &v
-}
-
 func (o ChannelTranscodeVideoEncodersInnerH265Hdr) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -152,9 +118,6 @@ func (o ChannelTranscodeVideoEncodersInnerH265Hdr) ToMap() (map[string]interface
 	}
 	if !IsNil(o.Hdr10) {
 		toSerialize["hdr10"] = o.Hdr10
-	}
-	if !IsNil(o.Hlg) {
-		toSerialize["hlg"] = o.Hlg
 	}
 	return toSerialize, nil
 }

--- a/isp/model_channel_transcode_video_encoders_inner_h265_hdr_dolby_vision.go
+++ b/isp/model_channel_transcode_video_encoders_inner_h265_hdr_dolby_vision.go
@@ -16,7 +16,7 @@ import (
 // checks if the ChannelTranscodeVideoEncodersInnerH265HdrDolbyVision type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &ChannelTranscodeVideoEncodersInnerH265HdrDolbyVision{}
 
-// ChannelTranscodeVideoEncodersInnerH265HdrDolbyVision Only one of ['hlg', 'hdr10', 'dolby_vision'] may be set.
+// ChannelTranscodeVideoEncodersInnerH265HdrDolbyVision Only one of ['hdr10', 'dolby_vision'] may be set.
 type ChannelTranscodeVideoEncodersInnerH265HdrDolbyVision struct {
 	// Only one of ['profile5', 'profile81', 'profile84'] may be set.
 	Profile5 *map[string]interface{} `json:"profile5,omitempty"`

--- a/isp/model_channel_transcode_video_encoders_inner_h265_hdr_hdr10.go
+++ b/isp/model_channel_transcode_video_encoders_inner_h265_hdr_hdr10.go
@@ -16,7 +16,7 @@ import (
 // checks if the ChannelTranscodeVideoEncodersInnerH265HdrHdr10 type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &ChannelTranscodeVideoEncodersInnerH265HdrHdr10{}
 
-// ChannelTranscodeVideoEncodersInnerH265HdrHdr10 Only one of ['hlg', 'hdr10', 'dolby_vision'] may be set.
+// ChannelTranscodeVideoEncodersInnerH265HdrHdr10 Only one of ['hdr10', 'dolby_vision'] may be set.
 type ChannelTranscodeVideoEncodersInnerH265HdrHdr10 struct {
 	Clli *ChannelTranscodeVideoEncodersInnerH265HdrDolbyVisionProfile81Clli `json:"clli,omitempty"`
 	Mdcv *ChannelTranscodeVideoEncodersInnerH265HdrDolbyVisionProfile81Mdcv `json:"mdcv,omitempty"`

--- a/prerequisites/client._go
+++ b/prerequisites/client._go
@@ -110,11 +110,10 @@ func (t *CloseableTransport) CloseIdleConnections() {
 func NewCloseableTransport(t http.RoundTripper) *CloseableTransport {
 	// Attempt to fail fast if we get an invalid transport. Still have to check
 	// later as e.g. `oauth2.Transport.Base` could change at runtime.
-	if _, ok := t.(*oauth2.Transport); ok {
-		// Ok
-	} else if _, ok := t.(idleConnectionsCloser); ok {
-		// Ok
-	} else {
+	switch t.(type) {
+	case *oauth2.Transport, idleConnectionsCloser:
+		// ok
+	default:
 		panic("HTTP transport does not implement IdleConnectionsCloser")
 	}
 	return &CloseableTransport{t}

--- a/prerequisites/client._go
+++ b/prerequisites/client._go
@@ -96,6 +96,10 @@ func (t *CloseableTransport) CloseIdleConnections() {
 		base = o.Base
 	}
 
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
 	if closer, ok := base.(idleConnectionsCloser); ok {
 		closer.CloseIdleConnections()
 	} else {


### PR DESCRIPTION
This PR fixes a bug when `http.DefaultTransport` is not an instance of `*http.Transport`, which can happen if you replace the default transport for e.g. automatic trace generation & propagation. It does:

1. Change `CloseableTransport` to wrap any `http.RoundTripper`
   1. Support `*oauth2.Transport`
   2. Support `*http.Transport`
   3. Support anything else that has a `CloseIdleConnections()` method
2. Remove some assumptions that were added in for regional failover support
   1. We aren't always dealing with `*oauth2.Transport` and/or `*http.Transport`
   2. Make no assumptions about `http.DefaultTransport`
4. Update to the latest Channel API OpenAPI, which removes a query param & HLG support.

After these changes it's possible to overwrite `http.DefaultTransport` with your own implementation (or pass in your own client with your own transport) and use the SDK as long as it implements the `CloseIdleConnections()` method.