### PR TITLE
fix: Allow gh cli to display error logs

### DIFF
--- a/.github/workflows/pr-comment-handler.yml
+++ b/.github/workflows/pr-comment-handler.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Determine PR details
         id: pr-details
         run: |
-          details=$(gh pr view ${{ github.event.issue.number }} --json 'baseRefName,headRefName' 2>&1)
+          details=$(gh pr view ${{ github.event.issue.number }} --json 'baseRefName,headRefName')
 
           headRefName=$(printf '%s' "$details" | jq -rc '.headRefName')
           baseRefName=$(printf '%s' "$details" | jq -rc '.baseRefName')

--- a/.github/workflows/pr-comment-handler.yml
+++ b/.github/workflows/pr-comment-handler.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 jobs:
 
   handle-comment:


### PR DESCRIPTION
Stop capturing [error output](https://github.com/istreamlabs/go-sdk/actions/runs/9471478075/job/26094779262). Also adding GH_TOKEN to attempt to fix this error.