### PR TITLE
fix: Re-generate PR using base instead of head

### DIFF
--- a/.github/workflows/pr-comment-handler.yml
+++ b/.github/workflows/pr-comment-handler.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'recreate-me') }}
     outputs:
-      pr-head: ${{ steps.pr-details.outputs.head }}
+      pr-base: ${{ steps.pr-details.outputs.base }}
     steps:
 
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     needs: [handle-comment]
     uses: ./.github/workflows/generate.yml
     with:
-      pr-base: ${{ needs.handle-comment.outputs.pr-head }}
+      pr-base: ${{ needs.handle-comment.outputs.pr-base }}
     secrets: inherit
           
   close-old:

--- a/.github/workflows/pr-comment-handler.yml
+++ b/.github/workflows/pr-comment-handler.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Determine PR details
         id: pr-details
         run: |
-          details=$(gh pr view ${{ github.event.issue.number }} --json 'baseRefName,headRefName' 2>&1)
+          details=$(gh pr view ${{ github.event.issue.number }} --json 'baseRefName,headRefName')
 
           headRefName=$(printf '%s' "$details" | jq -rc '.headRefName')
           baseRefName=$(printf '%s' "$details" | jq -rc '.baseRefName')

--- a/.github/workflows/pr-comment-handler.yml
+++ b/.github/workflows/pr-comment-handler.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 jobs:
 
   handle-comment:


### PR DESCRIPTION
When re-creating the PR, use base instead of head