### PR TITLE
fix: Fix permissions on SDK generation

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Detect generated changes
         id: changes
         run: |
-          git add .
+          git add isp isp-slate
           git status
 
           if [ -n "$(git status -s)" ]; then

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -55,10 +55,14 @@ jobs:
           echo "name=gen/$BASE/$DATE" | tee -a "$GITHUB_OUTPUT"
 
       - name: Re-generate isp
-        run: ./run.sh
+        run: |
+          ./run.sh
+          sudo chown -R $USER:$USER isp
 
       - name: Re-generate isp-slates
-        run: ./run-slate.sh
+        run: |
+          ./run-slate.sh
+          sudo chown -R $USER:$USER isp-slate
 
       - name: Detect generated changes
         id: changes

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -54,17 +54,15 @@ jobs:
           DATE=$(date '+%s')
           echo "name=gen/$BASE/$DATE" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Re-generate SDKs
+      - name: Re-generate isp
         run: |
-          echo "::group::isp"
           ./run.sh
           sudo chown -R $USER:$USER isp
-          echo "::endgroup::"
 
-          echo "::group::isp-slate"
+      - name: Re-generate isp-slate
+        run: |
           ./run-slate.sh
           sudo chown -R $USER:$USER isp-slate
-          echo "::endgroup::"
 
       - name: Detect generated changes
         id: changes

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -55,14 +55,10 @@ jobs:
           echo "name=gen/$BASE/$DATE" | tee -a "$GITHUB_OUTPUT"
 
       - name: Re-generate isp
-        run: |
-          ./run.sh
-          sudo chown -R $USER:$USER isp
+        run: ./run.sh
 
       - name: Re-generate isp-slate
-        run: |
-          ./run-slate.sh
-          sudo chown -R $USER:$USER isp-slate
+        run: ./run-slate.sh
 
       - name: Detect generated changes
         id: changes

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -54,15 +54,17 @@ jobs:
           DATE=$(date '+%s')
           echo "name=gen/$BASE/$DATE" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Re-generate isp
+      - name: Re-generate SDKs
         run: |
+          echo "::group::isp"
           ./run.sh
           sudo chown -R $USER:$USER isp
+          echo "::endgroup::"
 
-      - name: Re-generate isp-slates
-        run: |
+          echo "::group::isp-slate"
           ./run-slate.sh
           sudo chown -R $USER:$USER isp-slate
+          echo "::endgroup::"
 
       - name: Detect generated changes
         id: changes

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -70,7 +70,7 @@ jobs:
         id: changes
         run: |
           git add .
-          git status -s
+          git status
 
           if [ -n "$(git status -s)" ]; then
             echo "should-commit=true" | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -63,8 +63,7 @@ jobs:
       - name: Detect generated changes
         id: changes
         run: |
-          git add isp
-          git add isp-slate
+          git add .
           git status -s
 
           if [ -n "$(git status -s)" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 isp/api
+
+.DS_Store

--- a/run-slate.sh
+++ b/run-slate.sh
@@ -20,7 +20,7 @@ cp ./prerequisites/.openapi-generator-ignore ./isp-slate/.openapi-generator-igno
 cp ./prerequisites/convenience._go ./isp-slate/convenience.go
 cp ./prerequisites/slates_client._go ./isp-slate/client.go
 docker build -t generate-sdk . --no-cache --build-arg OPENAPI_SPEC="${OPENAPI_SPEC}" --build-arg OUT=isp-slate
-docker run --rm -v ${SCRIPT_DIR}/isp-slate:/go-sdk/isp-slate generate-sdk
+docker run -u "$(id -u):$(id -g)" --rm -v ${SCRIPT_DIR}/isp-slate:/go-sdk/isp-slate generate-sdk
 
 if [[ "$GITHUB_ACTIONS" = "true" ]]; then
   # Logicless templates are dumping extra quotes around enum values, so we've

--- a/run-slate.sh
+++ b/run-slate.sh
@@ -19,8 +19,18 @@ mkdir isp-slate
 cp ./prerequisites/.openapi-generator-ignore ./isp-slate/.openapi-generator-ignore
 cp ./prerequisites/convenience._go ./isp-slate/convenience.go
 cp ./prerequisites/slates_client._go ./isp-slate/client.go
-docker build -t generate-sdk . --no-cache --build-arg OPENAPI_SPEC="${OPENAPI_SPEC}" --build-arg OUT=isp-slate
-docker run -u "$(id -u):$(id -g)" --rm -v ${SCRIPT_DIR}/isp-slate:/go-sdk/isp-slate generate-sdk
+
+# build sdk generation image
+docker build -t generate-sdk . \
+  --no-cache \
+  --build-arg OPENAPI_SPEC="${OPENAPI_SPEC}" \
+  --build-arg OUT=isp-slate
+
+# generate sdk
+docker run --rm \
+  -u "$(id -u):$(id -g)" \
+  -v ${SCRIPT_DIR}/isp-slate:/go-sdk/isp-slate \
+  generate-sdk
 
 if [[ "$GITHUB_ACTIONS" = "true" ]]; then
   # Logicless templates are dumping extra quotes around enum values, so we've

--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ cp ./prerequisites/.openapi-generator-ignore ./isp/.openapi-generator-ignore
 cp ./prerequisites/convenience._go ./isp/convenience.go
 cp ./prerequisites/client._go ./isp/client.go
 docker build -t generate-sdk . --no-cache --build-arg OPENAPI_SPEC="${OPENAPI_SPEC}" --build-arg OUT=isp
-docker run --rm -v ${SCRIPT_DIR}/isp:/go-sdk/isp generate-sdk
+docker run -u "$(id -u):$(id -g)" --rm -v ${SCRIPT_DIR}/isp:/go-sdk/isp generate-sdk
 
 if [[ "$GITHUB_ACTIONS" = "true" ]]; then
   # Logicless templates are dumping extra quotes around enum values, so we've

--- a/run.sh
+++ b/run.sh
@@ -19,8 +19,18 @@ mkdir isp
 cp ./prerequisites/.openapi-generator-ignore ./isp/.openapi-generator-ignore
 cp ./prerequisites/convenience._go ./isp/convenience.go
 cp ./prerequisites/client._go ./isp/client.go
-docker build -t generate-sdk . --no-cache --build-arg OPENAPI_SPEC="${OPENAPI_SPEC}" --build-arg OUT=isp
-docker run -u "$(id -u):$(id -g)" --rm -v ${SCRIPT_DIR}/isp:/go-sdk/isp generate-sdk
+
+# build sdk generation image
+docker build -t generate-sdk . \
+  --no-cache \
+  --build-arg OPENAPI_SPEC="${OPENAPI_SPEC}" \
+  --build-arg OUT=isp
+
+# generate sdk
+docker run --rm \
+  -u "$(id -u):$(id -g)" \
+  -v ${SCRIPT_DIR}/isp:/go-sdk/isp \
+  generate-sdk
 
 if [[ "$GITHUB_ACTIONS" = "true" ]]; then
   # Logicless templates are dumping extra quotes around enum values, so we've


### PR DESCRIPTION
Generating the SDK is failing, due to [permissions errors on generated files](https://github.com/istreamlabs/go-sdk/actions/runs/9504248321). Seems to be https://github.com/peter-evans/create-pull-request/issues/783.