### PR TITLE
fix: Use zero fetch depth in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       -
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       -
         name: Tag new version
         id: tag


### PR DESCRIPTION
Use zero fetch depth to allow fetching tags

What went wrong: I expected [this workflow run](https://github.com/istreamlabs/go-sdk/actions/runs/9569641324/job/26382601377#step:3:17) to fetch the latest version correctly

Solution: We need to fetch the full repo history to determine latest version! Confirmed from the [tagging action's README](https://github.com/paulhatch/semantic-version/tree/v5.4.0/?tab=readme-ov-file#important-note-regarding-the-checkout-action)