### PR TITLE
fix: strip leading/trailing s from generated regex patterns

### DIFF
--- a/isp/model_channel.go
+++ b/isp/model_channel.go
@@ -30,7 +30,7 @@ type Channel struct {
 	// Indicates whether the channel's transcoder needs to run in a designated IP range.
 	EnableByoip *bool `json:"enable_byoip,omitempty" doc:"Indicates whether the channel's transcoder needs to run in a designated IP range."`
 	// External Channel ID provided at channel creation time
-	Id *string `json:"id,omitempty" minLength:"1" pattern:"/^([a-z0-9]+(-*[a-z0-9]+)*)$/" doc:"External Channel ID provided at channel creation time"`
+	Id *string `json:"id,omitempty" minLength:"1" pattern:"^([a-z0-9]+(-*[a-z0-9]+)*)$" doc:"External Channel ID provided at channel creation time"`
 	Ingest ChannelIngest `json:"ingest"`
 	// Optional labels for a channel. Any included labels must be at least 1 character long, but no greater than 256 characters. The maximum number of labels is 50.
 	Labels []string `json:"labels,omitempty" maxItems:"50" doc:"Optional labels for a channel. Any included labels must be at least 1 character long, but no greater than 256 characters. The maximum number of labels is 50."`

--- a/isp/model_channel_publishing_publications_inner_startover_on_airing_id.go
+++ b/isp/model_channel_publishing_publications_inner_startover_on_airing_id.go
@@ -19,7 +19,7 @@ var _ MappedNullable = &ChannelPublishingPublicationsInnerStartoverOnAiringId{}
 // ChannelPublishingPublicationsInnerStartoverOnAiringId Use the Airing Id of a Program Start to trigger a Startover on the first match. Only one of ['first_program_start', 'on_airing_id'] may be set.
 type ChannelPublishingPublicationsInnerStartoverOnAiringId struct {
 	// Airing Id is a SCTE-35 Segmentation Unique Program ID (UPID) of type 0x08 used to specify the unique airing of a program. Is a 8 byte hex encoded string that is prepended with '0x'.
-	AiringId *string `json:"airing_id,omitempty" pattern:"/^0x[0-9a-fA-F]{16}$/" doc:"Airing Id is a SCTE-35 Segmentation Unique Program ID (UPID) of type 0x08 used to specify the unique airing of a program. Is a 8 byte hex encoded string that is prepended with '0x'."`
+	AiringId *string `json:"airing_id,omitempty" pattern:"^0x[0-9a-fA-F]{16}$" doc:"Airing Id is a SCTE-35 Segmentation Unique Program ID (UPID) of type 0x08 used to specify the unique airing of a program. Is a 8 byte hex encoded string that is prepended with '0x'."`
 }
 
 // NewChannelPublishingPublicationsInnerStartoverOnAiringId instantiates a new ChannelPublishingPublicationsInnerStartoverOnAiringId object

--- a/isp/model_channel_publishing_rtmp_publications_inner.go
+++ b/isp/model_channel_publishing_rtmp_publications_inner.go
@@ -21,8 +21,8 @@ type ChannelPublishingRtmpPublicationsInner struct {
 	// Only AAC encoders are supported
 	AudioEncoderId *string `json:"audio_encoder_id,omitempty" minLength:"1" doc:"Only AAC encoders are supported"`
 	// RTMP publication ID. Must be unique.
-	Id *string `json:"id,omitempty" minLength:"1" pattern:"/^([a-z0-9]+(-*[a-z0-9]+)*)$/" doc:"RTMP publication ID. Must be unique."`
-	Url *string `json:"url,omitempty" format:"uri" minLength:"1" pattern:"/^rtmps?:\/\//"`
+	Id *string `json:"id,omitempty" minLength:"1" pattern:"^([a-z0-9]+(-*[a-z0-9]+)*)$" doc:"RTMP publication ID. Must be unique."`
+	Url *string `json:"url,omitempty" format:"uri" minLength:"1" pattern:"^rtmps?:\/\/"`
 	// Only h264 encoders are supported
 	VideoEncoderId *string `json:"video_encoder_id,omitempty" minLength:"1" doc:"Only h264 encoders are supported"`
 }

--- a/isp/model_channel_publishing_srt_publications_inner.go
+++ b/isp/model_channel_publishing_srt_publications_inner.go
@@ -20,12 +20,12 @@ var _ MappedNullable = &ChannelPublishingSrtPublicationsInner{}
 type ChannelPublishingSrtPublicationsInner struct {
 	AudioEncoders []ChannelPublishingSrtPublicationsInnerAudioEncodersInner `json:"audio_encoders,omitempty" minItems:"1"`
 	// SRT publication ID. Must be unique.
-	Id *string `json:"id,omitempty" minLength:"1" pattern:"/^([a-z0-9]+(-*[a-z0-9]+)*)$/" doc:"SRT publication ID. Must be unique."`
+	Id *string `json:"id,omitempty" minLength:"1" pattern:"^([a-z0-9]+(-*[a-z0-9]+)*)$" doc:"SRT publication ID. Must be unique."`
 	// MPEG-TS PMT PID. PIDs should be set on the PMT, SCTE-35 and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically.
 	PmtPid *int32 `json:"pmt_pid,omitempty" format:"int32" exclusiveMaximum:"8191" doc:"MPEG-TS PMT PID. PIDs should be set on the PMT, SCTE-35 and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically."`
 	// MPEG-TS SCTE-35 PID. PIDs should be set on the PMT, SCTE-35, and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically.
 	Scte35Pid *int32 `json:"scte35_pid,omitempty" format:"int32" exclusiveMaximum:"8191" doc:"MPEG-TS SCTE-35 PID. PIDs should be set on the PMT, SCTE-35, and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically."`
-	Url *string `json:"url,omitempty" format:"uri" minLength:"1" pattern:"/^srt:\/\//"`
+	Url *string `json:"url,omitempty" format:"uri" minLength:"1" pattern:"^srt:\/\/"`
 	VideoEncoders []ChannelPublishingSrtPublicationsInnerAudioEncodersInner `json:"video_encoders,omitempty" minItems:"1"`
 }
 

--- a/isp/model_is_breaking_change_return.go
+++ b/isp/model_is_breaking_change_return.go
@@ -21,7 +21,7 @@ type IsBreakingChangeReturn struct {
 	// An optional URL to a JSON Schema document describing this resource
 	Schema *string `json:"$schema,omitempty" format:"uri" doc:"An optional URL to a JSON Schema document describing this resource"`
 	// Unique channel identifier
-	Channelid string `json:"channelid" maxLength:"60" pattern:"/^([a-z0-9]+(-*[a-z0-9]+)*)$/" doc:"Unique channel identifier"`
+	Channelid string `json:"channelid" maxLength:"60" pattern:"^([a-z0-9]+(-*[a-z0-9]+)*)$" doc:"Unique channel identifier"`
 	// The current revision of the channel.
 	CurrentRevision int32 `json:"currentRevision" format:"int32" doc:"The current revision of the channel."`
 	// True if the change will cause a break in user playback. False if the change will not cause a break in user playback or the channel doesn't exist

--- a/isp/model_patch_org_channel_request.go
+++ b/isp/model_patch_org_channel_request.go
@@ -30,7 +30,7 @@ type PatchOrgChannelRequest struct {
 	// Indicates whether the channel's transcoder needs to run in a designated IP range.
 	EnableByoip *bool `json:"enable_byoip,omitempty" doc:"Indicates whether the channel's transcoder needs to run in a designated IP range."`
 	// External Channel ID provided at channel creation time
-	Id *string `json:"id,omitempty" minLength:"1" pattern:"/^([a-z0-9]+(-*[a-z0-9]+)*)$/" doc:"External Channel ID provided at channel creation time"`
+	Id *string `json:"id,omitempty" minLength:"1" pattern:"^([a-z0-9]+(-*[a-z0-9]+)*)$" doc:"External Channel ID provided at channel creation time"`
 	Ingest *PatchOrgChannelRequestIngest `json:"ingest,omitempty"`
 	// Optional labels for a channel. Any included labels must be at least 1 character long, but no greater than 256 characters. The maximum number of labels is 50.
 	Labels []string `json:"labels,omitempty" maxItems:"50" doc:"Optional labels for a channel. Any included labels must be at least 1 character long, but no greater than 256 characters. The maximum number of labels is 50."`

--- a/isp/model_put_org_channel_request.go
+++ b/isp/model_put_org_channel_request.go
@@ -30,7 +30,7 @@ type PutOrgChannelRequest struct {
 	// Indicates whether the channel's transcoder needs to run in a designated IP range.
 	EnableByoip *bool `json:"enable_byoip,omitempty" doc:"Indicates whether the channel's transcoder needs to run in a designated IP range."`
 	// External Channel ID provided at channel creation time
-	Id *string `json:"id,omitempty" minLength:"1" pattern:"/^([a-z0-9]+(-*[a-z0-9]+)*)$/" doc:"External Channel ID provided at channel creation time"`
+	Id *string `json:"id,omitempty" minLength:"1" pattern:"^([a-z0-9]+(-*[a-z0-9]+)*)$" doc:"External Channel ID provided at channel creation time"`
 	Ingest PutOrgChannelRequestIngest `json:"ingest"`
 	// Optional labels for a channel. Any included labels must be at least 1 character long, but no greater than 256 characters. The maximum number of labels is 50.
 	Labels []string `json:"labels,omitempty" maxItems:"50" doc:"Optional labels for a channel. Any included labels must be at least 1 character long, but no greater than 256 characters. The maximum number of labels is 50."`

--- a/run.sh
+++ b/run.sh
@@ -74,6 +74,11 @@ sed -i.bak -E 's/@@@@"([^"]+)"@@@@/\1/g' ./${API}/*.go
 # got to remove those.
 sed -i.bak -E 's/ example:"null"//g' ./${API}/*.go
 
+# Strip leading/trailing regex delimiters added by generator (e.g., "/^...$/")
+# Restrict to struct tag context (inside backticks) to avoid accidental matches.
+# Note: Use POSIX ERE (no \b). Tested with BSD sed (macOS).
+sed -i.bak -E 's/(`[^`]*pattern:")\/([^"]*)\/(")/\1\2\3/g' ./${API}/*.go
+
 # Correct an error in the unit tests
 sed -i.bak -E 's,"github.com/istreamlabs/go-sdk/isp","github.com/istreamlabs/go-sdk/isp-slate",g' ./isp-slate/**/*.go
 sed -i.bak -E 's,"github.com/istreamlabs/go-sdk/isp","github.com/istreamlabs/go-sdk/isp-lifecycle",g' ./isp-lifecycle/**/*.go


### PR DESCRIPTION
The SDK has been adding delimiters to regex, making a lot of our regex invalid. This hasn't really impacted us yet because the validations we tend to do are on the Aventus side.

What will typically happen is LCP will receive an HTTP request, run validation (where there are no regex fields, because those fields are all Aventus concepts), and the validation works. Then LCP creates a payload and sends to Aventus. The Huma validation on the Aventus side passes because the regex is correct on the Aventus side.

This case has become an issue now that LEAD is trying to create an RTMP template – they need to add an rtmp ID (because it's required), but all regex fails. 