### PR TITLE
chore: Add dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+-
+  package-ecosystem: github-actions
+  directory: /
+  open-pull-requests-limit: 5
+  schedule:
+    interval: weekly
+    day: friday
+    time: "08:00"
+    timezone: America/Los_Angeles
+  allow:
+    - dependency-type: direct
+  ignore:
+    - dependency-name: '*'
+      update-types: [version-update:semver-patch]


### PR DESCRIPTION
Noticed some of our actions are very out of date. This should help