### PR TITLE
fix(LIVE-22579): Updating to /v2 naming conveion for major version change

### DIFF
--- a/.generator.yaml
+++ b/.generator.yaml
@@ -4,5 +4,5 @@ generateInterfaces: true
 isGoSubmodule: true
 packageName: isp
 gitUserId: istreamlabs
-gitRepoId: go-sdk
+gitRepoId: go-sdk/v2
 validateSpec: false

--- a/doc.go
+++ b/doc.go
@@ -8,7 +8,7 @@ Getting Started
 The best way to get started working with the SDK is to use `go get` to add the
 SDK:
 
-	go get github.com/istreamlabs/go-sdk/isp
+	go get github.com/istreamlabs/go-sdk/v2/isp
 
 Hello iStreamPlanet
 
@@ -21,7 +21,7 @@ sources available to you.
 		"context"
 		"fmt"
 
-		"github.com/istreamlabs/go-sdk/isp"
+		"github.com/istreamlabs/go-sdk/v2/isp"
 	)
 
 	func main() {

--- a/example/example.go
+++ b/example/example.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/istreamlabs/go-sdk/isp"
+	"github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func main() {

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/istreamlabs/go-sdk/isp"
+	"github.com/istreamlabs/go-sdk/v2/isp"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,19 @@
-module github.com/istreamlabs/go-sdk
+module github.com/istreamlabs/go-sdk/v2
 
-go 1.13
+go 1.22
 
 require (
-	github.com/stretchr/testify v1.8.4 // indirect
+	github.com/stretchr/testify v1.8.4
 	github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e // indirect
+	google.golang.org/appengine v1.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,10 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9 h1:/Bsw4C+DEdqPjt8vAqaC9LAqpAQnaCQQqmolqq3S1T4=
@@ -25,7 +19,9 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=

--- a/isp-lifecycle/test/api_lifecycle_test.go
+++ b/isp-lifecycle/test/api_lifecycle_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp-lifecycle"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp-lifecycle"
 )
 
 func Test_isp_LifecycleApiService(t *testing.T) {

--- a/isp-slate/test/api_slates_for_organization_test.go
+++ b/isp-slate/test/api_slates_for_organization_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp-slate"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp-slate"
 )
 
 func Test_isp_SlatesForOrganizationApiService(t *testing.T) {

--- a/isp/test/api_audit_operations_for_organization_test.go
+++ b/isp/test/api_audit_operations_for_organization_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_AuditOperationsForOrganizationApiService(t *testing.T) {

--- a/isp/test/api_available_sources_test.go
+++ b/isp/test/api_available_sources_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_AvailableSourcesApiService(t *testing.T) {

--- a/isp/test/api_channel_operations_for_organization_test.go
+++ b/isp/test/api_channel_operations_for_organization_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_ChannelOperationsForOrganizationApiService(t *testing.T) {

--- a/isp/test/api_channels_for_organization_test.go
+++ b/isp/test/api_channels_for_organization_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_ChannelsForOrganizationApiService(t *testing.T) {

--- a/isp/test/api_channels_test.go
+++ b/isp/test/api_channels_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_ChannelsApiService(t *testing.T) {

--- a/isp/test/api_deprecated_live2_vod_test.go
+++ b/isp/test/api_deprecated_live2_vod_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_DeprecatedLive2VODApiService(t *testing.T) {

--- a/isp/test/api_live2_vod_for_organization_test.go
+++ b/isp/test/api_live2_vod_for_organization_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_Live2VODForOrganizationApiService(t *testing.T) {

--- a/isp/test/api_organizations_test.go
+++ b/isp/test/api_organizations_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_OrganizationsApiService(t *testing.T) {

--- a/isp/test/api_source_previews_test.go
+++ b/isp/test/api_source_previews_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_SourcePreviewsApiService(t *testing.T) {

--- a/isp/test/api_transcoder_telemetry_test.go
+++ b/isp/test/api_transcoder_telemetry_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/istreamlabs/go-sdk/isp"
+	openapiclient "github.com/istreamlabs/go-sdk/v2/isp"
 )
 
 func Test_isp_TranscoderTelemetryApiService(t *testing.T) {

--- a/run.sh
+++ b/run.sh
@@ -84,8 +84,8 @@ sed -i.bak -E 's/ example:"null"//g' ./${API}/*.go
 sed -i.bak -E 's/(`[^`]*pattern:")\/([^"]*)\/(")/\1\2\3/g' ./${API}/*.go
 
 # Correct an error in the unit tests
-sed -i.bak -E 's,"github.com/istreamlabs/go-sdk/isp","github.com/istreamlabs/go-sdk/isp-slate",g' ./isp-slate/**/*.go
-sed -i.bak -E 's,"github.com/istreamlabs/go-sdk/isp","github.com/istreamlabs/go-sdk/isp-lifecycle",g' ./isp-lifecycle/**/*.go
+sed -i.bak -E 's,"github.com/istreamlabs/go-sdk/v2/isp","github.com/istreamlabs/go-sdk/v2/isp-slate",g' ./isp-slate/**/*.go
+sed -i.bak -E 's,"github.com/istreamlabs/go-sdk/v2/isp","github.com/istreamlabs/go-sdk/v2/isp-lifecycle",g' ./isp-lifecycle/**/*.go
 
 # Cleanup all sed backups
 find . -name '*.bak' -delete


### PR DESCRIPTION
Go does not allow you to upgrade a major version change without changing the name to this convention for versions >= 2.