### PR TITLE
fix(LIVE-22579): use SrtPublicationEncoder for srt_publications[].video_encoders

### DIFF
--- a/isp/model_patch_org_channel_request_publishing_srt_publications_inner.go
+++ b/isp/model_patch_org_channel_request_publishing_srt_publications_inner.go
@@ -26,7 +26,7 @@ type PatchOrgChannelRequestPublishingSrtPublicationsInner struct {
 	// MPEG-TS SCTE-35 PID. PIDs should be set on the PMT, SCTE-35, and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically.
 	Scte35Pid *int32 `json:"scte35_pid,omitempty" format:"int32" exclusiveMaximum:"8191" doc:"MPEG-TS SCTE-35 PID. PIDs should be set on the PMT, SCTE-35, and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically."`
 	Url *string `json:"url,omitempty" format:"uri" minLength:"1" pattern:"^srt:\/\/"`
-	VideoEncoders []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner `json:"video_encoders,omitempty" minItems:"1"`
+	VideoEncoders []SrtPublicationEncoder `json:"video_encoders,omitempty" minItems:"1"`
 }
 
 // NewPatchOrgChannelRequestPublishingSrtPublicationsInner instantiates a new PatchOrgChannelRequestPublishingSrtPublicationsInner object
@@ -207,9 +207,9 @@ func (o *PatchOrgChannelRequestPublishingSrtPublicationsInner) SetUrl(v string) 
 }
 
 // GetVideoEncoders returns the VideoEncoders field value if set, zero value otherwise.
-func (o *PatchOrgChannelRequestPublishingSrtPublicationsInner) GetVideoEncoders() []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner {
+func (o *PatchOrgChannelRequestPublishingSrtPublicationsInner) GetVideoEncoders() []SrtPublicationEncoder {
 	if o == nil || IsNil(o.VideoEncoders) {
-		var ret []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner
+		var ret []SrtPublicationEncoder
 		return ret
 	}
 	return o.VideoEncoders
@@ -217,7 +217,7 @@ func (o *PatchOrgChannelRequestPublishingSrtPublicationsInner) GetVideoEncoders(
 
 // GetVideoEncodersOk returns a tuple with the VideoEncoders field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PatchOrgChannelRequestPublishingSrtPublicationsInner) GetVideoEncodersOk() ([]PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner, bool) {
+func (o *PatchOrgChannelRequestPublishingSrtPublicationsInner) GetVideoEncodersOk() ([]SrtPublicationEncoder, bool) {
 	if o == nil || IsNil(o.VideoEncoders) {
 		return nil, false
 	}
@@ -233,8 +233,8 @@ func (o *PatchOrgChannelRequestPublishingSrtPublicationsInner) HasVideoEncoders(
 	return false
 }
 
-// SetVideoEncoders gets a reference to the given []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner and assigns it to the VideoEncoders field.
-func (o *PatchOrgChannelRequestPublishingSrtPublicationsInner) SetVideoEncoders(v []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner) {
+// SetVideoEncoders gets a reference to the given []SrtPublicationEncoder and assigns it to the VideoEncoders field.
+func (o *PatchOrgChannelRequestPublishingSrtPublicationsInner) SetVideoEncoders(v []SrtPublicationEncoder) {
 	o.VideoEncoders = v
 }
 

--- a/isp/model_publishing_srt_publications_inner.go
+++ b/isp/model_publishing_srt_publications_inner.go
@@ -26,7 +26,7 @@ type PublishingSrtPublicationsInner struct {
 	// MPEG-TS SCTE-35 PID. PIDs should be set on the PMT, SCTE-35, and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically.
 	Scte35Pid *int32 `json:"scte35_pid,omitempty" format:"int32" exclusiveMaximum:"8191" doc:"MPEG-TS SCTE-35 PID. PIDs should be set on the PMT, SCTE-35, and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically."`
 	Url *string `json:"url,omitempty" format:"uri" minLength:"1" pattern:"^srt:\/\/"`
-	VideoEncoders []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner `json:"video_encoders,omitempty" minItems:"1"`
+	VideoEncoders []SrtPublicationEncoder `json:"video_encoders,omitempty" minItems:"1"`
 }
 
 // NewPublishingSrtPublicationsInner instantiates a new PublishingSrtPublicationsInner object
@@ -208,9 +208,9 @@ func (o *PublishingSrtPublicationsInner) SetUrl(v string) {
 }
 
 // GetVideoEncoders returns the VideoEncoders field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *PublishingSrtPublicationsInner) GetVideoEncoders() []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner {
+func (o *PublishingSrtPublicationsInner) GetVideoEncoders() []SrtPublicationEncoder {
 	if o == nil {
-		var ret []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner
+		var ret []SrtPublicationEncoder
 		return ret
 	}
 	return o.VideoEncoders
@@ -219,7 +219,7 @@ func (o *PublishingSrtPublicationsInner) GetVideoEncoders() []PatchOrgChannelReq
 // GetVideoEncodersOk returns a tuple with the VideoEncoders field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *PublishingSrtPublicationsInner) GetVideoEncodersOk() ([]PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner, bool) {
+func (o *PublishingSrtPublicationsInner) GetVideoEncodersOk() ([]SrtPublicationEncoder, bool) {
 	if o == nil || IsNil(o.VideoEncoders) {
 		return nil, false
 	}
@@ -235,8 +235,8 @@ func (o *PublishingSrtPublicationsInner) HasVideoEncoders() bool {
 	return false
 }
 
-// SetVideoEncoders gets a reference to the given []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner and assigns it to the VideoEncoders field.
-func (o *PublishingSrtPublicationsInner) SetVideoEncoders(v []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner) {
+// SetVideoEncoders gets a reference to the given []SrtPublicationEncoder and assigns it to the VideoEncoders field.
+func (o *PublishingSrtPublicationsInner) SetVideoEncoders(v []SrtPublicationEncoder) {
 	o.VideoEncoders = v
 }
 

--- a/isp/model_srt_publication.go
+++ b/isp/model_srt_publication.go
@@ -26,7 +26,7 @@ type SrtPublication struct {
 	// MPEG-TS SCTE-35 PID. PIDs should be set on the PMT, SCTE-35, and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically.
 	Scte35Pid *int32 `json:"scte35_pid,omitempty" format:"int32" exclusiveMaximum:"8191" doc:"MPEG-TS SCTE-35 PID. PIDs should be set on the PMT, SCTE-35, and all encoders or none. Valid PIDs must 13-bit values greater than 31. If no PIDs are provided (pid == 0) then they will be generated automatically."`
 	Url *string `json:"url,omitempty" format:"uri" minLength:"1" pattern:"^srt:\/\/"`
-	VideoEncoders []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner `json:"video_encoders,omitempty" minItems:"1"`
+	VideoEncoders []SrtPublicationEncoder `json:"video_encoders,omitempty" minItems:"1"`
 }
 
 // NewSrtPublication instantiates a new SrtPublication object
@@ -208,9 +208,9 @@ func (o *SrtPublication) SetUrl(v string) {
 }
 
 // GetVideoEncoders returns the VideoEncoders field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SrtPublication) GetVideoEncoders() []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner {
+func (o *SrtPublication) GetVideoEncoders() []SrtPublicationEncoder {
 	if o == nil {
-		var ret []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner
+		var ret []SrtPublicationEncoder
 		return ret
 	}
 	return o.VideoEncoders
@@ -219,7 +219,7 @@ func (o *SrtPublication) GetVideoEncoders() []PatchOrgChannelRequestPublishingSr
 // GetVideoEncodersOk returns a tuple with the VideoEncoders field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SrtPublication) GetVideoEncodersOk() ([]PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner, bool) {
+func (o *SrtPublication) GetVideoEncodersOk() ([]SrtPublicationEncoder, bool) {
 	if o == nil || IsNil(o.VideoEncoders) {
 		return nil, false
 	}
@@ -235,8 +235,8 @@ func (o *SrtPublication) HasVideoEncoders() bool {
 	return false
 }
 
-// SetVideoEncoders gets a reference to the given []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner and assigns it to the VideoEncoders field.
-func (o *SrtPublication) SetVideoEncoders(v []PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner) {
+// SetVideoEncoders gets a reference to the given []SrtPublicationEncoder and assigns it to the VideoEncoders field.
+func (o *SrtPublication) SetVideoEncoders(v []SrtPublicationEncoder) {
 	o.VideoEncoders = v
 }
 

--- a/run.sh
+++ b/run.sh
@@ -84,7 +84,7 @@ sed -i.bak -E 's/ example:"null"//g' ./${API}/*.go
 sed -i.bak -E 's/(`[^`]*pattern:")\/([^"]*)\/(")/\1\2\3/g' ./${API}/*.go
 
 # OpenAPI Generator emits PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner
-# for srt_publications[].video_encoders but never generates that model; the spec uses
+# for srt_publications[].video_encoders but never generates that model. The spec uses
 # components/schemas/SrtPublicationEncoder (same as audio_encoders).
 sed -i.bak -E 's/PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner/SrtPublicationEncoder/g' ./${API}/*.go
 

--- a/run.sh
+++ b/run.sh
@@ -83,6 +83,11 @@ sed -i.bak -E 's/ example:"null"//g' ./${API}/*.go
 # Note: Use POSIX ERE (no \b). Tested with BSD sed (macOS).
 sed -i.bak -E 's/(`[^`]*pattern:")\/([^"]*)\/(")/\1\2\3/g' ./${API}/*.go
 
+# OpenAPI Generator emits PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner
+# for srt_publications[].video_encoders but never generates that model; the spec uses
+# components/schemas/SrtPublicationEncoder (same as audio_encoders).
+sed -i.bak -E 's/PatchOrgChannelRequestPublishingSrtPublicationsInnerVideoEncodersInner/SrtPublicationEncoder/g' ./${API}/*.go
+
 # Correct an error in the unit tests
 sed -i.bak -E 's,"github.com/istreamlabs/go-sdk/v2/isp","github.com/istreamlabs/go-sdk/v2/isp-slate",g' ./isp-slate/**/*.go
 sed -i.bak -E 's,"github.com/istreamlabs/go-sdk/v2/isp","github.com/istreamlabs/go-sdk/v2/isp-lifecycle",g' ./isp-lifecycle/**/*.go


### PR DESCRIPTION
the sdk failed to build because the generated `video_encoders` field on the SRT publication models references a type that was never emitted.  The huma v1 → v2 upgrade changed how object schemas are laid out in the OpenAPI spec, and in this one spot OpenAPI Generator invented a new name for the `video_encoders` item type and then failed to emit a model for it, even though the spec points to `SrtPublicationEncoder`, which is the same type already used (and working) for `audio_encoders`. 

This PR fixes the three affected models to use `SrtPublicationEncoder` and adds a small `sed` step in `run.sh` so regenerations stay correct.